### PR TITLE
GH-129 Use PaperItemBuilder in leaderboard menu to fix crash on modern Paper

### DIFF
--- a/eternaleconomy-core/build.gradle.kts
+++ b/eternaleconomy-core/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation("org.bstats:bstats-bukkit:${Versions.BSTATS_BUKKIT}")
 
     // TriumphGUI for GUI
-    implementation("dev.triumphteam:triumph-gui:${Versions.TRIUMPH_GUI}")
+    implementation("dev.triumphteam:triumph-gui-paper:${Versions.TRIUMPH_GUI}")
     paperLibrary("dev.rollczi:liteskullapi:${Versions.LITE_SKULL_API}")
 
     testImplementation(platform("org.junit:junit-bom:6.0.3"))

--- a/eternaleconomy-core/src/main/java/com/eternalcode/economy/leaderboard/menu/LeaderboardItemRepresenter.java
+++ b/eternaleconomy-core/src/main/java/com/eternalcode/economy/leaderboard/menu/LeaderboardItemRepresenter.java
@@ -3,7 +3,7 @@ package com.eternalcode.economy.leaderboard.menu;
 import com.eternalcode.economy.MiniMessageHolder;
 import com.eternalcode.multification.shared.Formatter;
 import dev.rollczi.liteskullapi.SkullAPI;
-import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.builder.item.PaperItemBuilder;
 import dev.triumphteam.gui.components.GuiAction;
 import dev.triumphteam.gui.guis.GuiItem;
 import eu.okaeri.configs.annotation.Exclude;
@@ -92,16 +92,16 @@ public class LeaderboardItemRepresenter implements Serializable, MiniMessageHold
 
         Component nameComponent = RESET_ITEM.append(MINI_MESSAGE.deserialize(formatter.format(this.name)));
 
-        ItemBuilder builder;
+        PaperItemBuilder builder;
 
         if (preloadedSkull != null) {
-            builder = ItemBuilder.from(preloadedSkull);
+            builder = PaperItemBuilder.from(preloadedSkull);
         }
         else if (this.texture != null && !this.texture.equals("none") && skullAPI != null) {
-            builder = ItemBuilder.from(Material.PLAYER_HEAD);
+            builder = PaperItemBuilder.from(Material.PLAYER_HEAD);
         }
         else {
-            builder = ItemBuilder.from(this.material);
+            builder = PaperItemBuilder.from(this.material);
         }
 
         builder.name(nameComponent)

--- a/eternaleconomy-core/src/main/java/com/eternalcode/economy/leaderboard/menu/LeaderboardMenu.java
+++ b/eternaleconomy-core/src/main/java/com/eternalcode/economy/leaderboard/menu/LeaderboardMenu.java
@@ -9,7 +9,7 @@ import com.eternalcode.economy.leaderboard.LeaderboardPage;
 import com.eternalcode.economy.leaderboard.LeaderboardService;
 import com.eternalcode.multification.shared.Formatter;
 import dev.rollczi.liteskullapi.SkullAPI;
-import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.builder.item.PaperItemBuilder;
 import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import java.util.ArrayList;
@@ -115,8 +115,8 @@ public class LeaderboardMenu implements MiniMessageHolder {
         if (this.config.fillSettings.enableFillItems) {
             gui.getFiller().fill(
                 this.config.fillSettings.fillItems.stream()
-                    .map(ItemBuilder::from)
-                    .map(ItemBuilder::asGuiItem)
+                    .map(PaperItemBuilder::from)
+                    .map(PaperItemBuilder::asGuiItem)
                     .toList()
             );
         }


### PR DESCRIPTION
The leaderboard menu used **triumph-gui's `BukkitItemBuilder`**, which serializes item names and lore through **adventure-platform's `MinecraftComponentSerializer`**. The bundled `adventure-platform` was built against an older `adventure-api` and is incompatible with newer Paper versions where `ComponentFlattener.toBuilder()` no longer exists, causing the menu to crash while rendering.

```text
java.lang.UnsupportedOperationException: java.lang.NoClassDefFoundError: Could not initialize class net.kyori.adventure.platform.bukkit.BukkitComponentSerializer

Caused by: java.lang.NoSuchMethodError:
'net.kyori.adventure.util.Buildable$Builder net.kyori.adventure.text.flattener.ComponentFlattener.toBuilder()'
```

Since EternalEconomy is a Paper plugin, switching to the **`triumph-gui-paper`** artifact and **`PaperItemBuilder`** avoids this issue entirely. `PaperItemBuilder` sets item names and lore using Paper's native Adventure API (`ItemMeta#displayName()` / `ItemMeta#lore()`) instead of the legacy serializer, eliminating the compatibility issue with modern Paper versions. with a help with a little bit of a clanker....