### PR TITLE
GH-150 Fix Java 21 build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Grant execute permission for gradlew

--- a/buildSrc/src/main/kotlin/economy-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/economy-java.gradle.kts
@@ -12,7 +12,7 @@ java {
 tasks.compileJava {
     options.compilerArgs = listOf("-Xlint:deprecation", "-parameters")
     options.encoding = "UTF-8"
-    options.release = 17
+    options.release = 21
 }
 
 tasks.test {


### PR DESCRIPTION
# What does this PR change?
This fixes the Java version mismatch in the build setup.
The project already uses a Java 21 toolchain, but compiles using Java 17. I also noticed that the Github Actions workflow was also using Java 17.
That no longer works with some of the dependencies, which now require a more up to date version aka Java 21.

## Changes
- Changed the Java release target to Java 21
- Updated the Github Actions build workflow to also use Java 21

### Why?
Without this, the build fails during dependency resolution with errors like:
`Dependency resolution is looking for a library compatible with JVM runtime version 17, but the dependency is only compatible with JVM runtime version 21 or newer.`

This just makes the build configuration match the Java version the project is already expecting.

### Testing
Tested with:
`./gradlew clean eternaleconomy-core:shadowJar`
the build completes successfully after the change.